### PR TITLE
Updates for ufs/dev PR#30

### DIFF
--- a/physics/GFS_MP_generic_post.F90
+++ b/physics/GFS_MP_generic_post.F90
@@ -20,11 +20,11 @@
 !> @{
       subroutine GFS_MP_generic_post_run(                                                                                 &
         im, levs, kdt, nrcm, nncl, ntcw, ntrac, imp_physics, imp_physics_gfdl, imp_physics_thompson, imp_physics_nssl,    &
-        imp_physics_mg, imp_physics_fer_hires, cal_pre, cplflx, cplchm, cpllnd, progsigma, con_g, rainmin, dtf, frain, rainc,    &
-        rain1, rann, xlat, xlon, gt0, gq0, prsl, prsi, phii, tsfc, ice, snow, graupel, save_t, save_q, rain0, ice0, snow0,&
-        graupel0, del, rain, domr_diag, domzr_diag, domip_diag, doms_diag, tprcp, srflag, sr, cnvprcp, totprcp, totice,   &
-        totsnw, totgrp, cnvprcpb, totprcpb, toticeb, totsnwb, totgrpb, rain_cpl, rainc_cpl, snow_cpl, pwat,               &
-        frzr, frzrb, frozr, frozrb, tsnowp, tsnowpb, rhonewsn1, vrbliceden_noah, iopt_snf,                                & 
+        imp_physics_mg, imp_physics_fer_hires, cal_pre, cplflx, cplchm, cpllnd, progsigma, con_g, rhowater, rainmin, dtf, &
+        frain, rainc, rain1, rann, xlat, xlon, gt0, gq0, prsl, prsi, phii, tsfc, ice, snow, graupel, save_t, save_q,      &
+        rain0, ice0, snow0, graupel0, del, rain, domr_diag, domzr_diag, domip_diag, doms_diag, tprcp, srflag, sr, cnvprcp,&
+        totprcp, totice, totsnw, totgrp, cnvprcpb, totprcpb, toticeb, totsnwb, totgrpb, rain_cpl, rainc_cpl, snow_cpl,    &
+        pwat, frzr, frzrb, frozr, frozrb, tsnowp, tsnowpb, rhonewsn1, vrbliceden_noah, iopt_snf,                          & 
         drain_cpl, dsnow_cpl, lsm, lsm_ruc, lsm_noahmp, raincprv, rainncprv, iceprv, snowprv,                             &
         graupelprv, draincprv, drainncprv, diceprv, dsnowprv, dgraupelprv, dtp, dfi_radar_max_intervals,                  &
         dtend, dtidx, index_of_temperature, index_of_process_mp,ldiag3d, qdiag3d,dqdt_qmicro, lssav, num_dfi_radar,       &
@@ -47,7 +47,7 @@
       integer                                                :: ix_dfi_radar(:)
       real(kind=kind_phys), dimension(:,:),    intent(inout) :: gt0
 
-      real(kind=kind_phys),                    intent(in)    :: dtf, frain, con_g, rainmin
+      real(kind=kind_phys),                    intent(in)    :: dtf, frain, con_g, rainmin, rhowater
       real(kind=kind_phys), dimension(:),      intent(in)    :: rain1, xlat, xlon, tsfc
       real(kind=kind_phys), dimension(:),      intent(inout) :: ice, snow, graupel, rainc
       real(kind=kind_phys), dimension(:),      intent(in)    :: rain0, ice0, snow0, graupel0
@@ -111,7 +111,6 @@
 
       real :: snowrat,grauprat,icerat,curat,prcpncfr,prcpcufr
       real :: rhonewsnow,rhoprcpice,rhonewgr,rhonewice
-      real(kind=kind_phys), parameter :: rhowater = 1000.0_kind_phys
 
       ! Initialize CCPP error handling variables
       errmsg = ''
@@ -136,7 +135,7 @@
             frozrb(i) = frozrb(i) + graupel0(i)
          enddo
 !Compute the variable precip ice density for specific LSM schemes and options
-         if ( lsm == lsm_ruc .or. lsm == lsm_noahmp .and. iopt_snf == 5 .or. vrbliceden_noah == .true.) then
+         if ( lsm == lsm_ruc .or. (lsm == lsm_noahmp .and. iopt_snf == 5) .or. vrbliceden_noah == .true.) then
             snowrat = 0.
             grauprat = 0.
             icerat = 0.

--- a/physics/GFS_MP_generic_post.F90
+++ b/physics/GFS_MP_generic_post.F90
@@ -24,7 +24,7 @@
         frain, rainc, rain1, rann, xlat, xlon, gt0, gq0, prsl, prsi, phii, tsfc, ice, snow, graupel, save_t, save_q,      &
         rain0, ice0, snow0, graupel0, del, rain, domr_diag, domzr_diag, domip_diag, doms_diag, tprcp, srflag, sr, cnvprcp,&
         totprcp, totice, totsnw, totgrp, cnvprcpb, totprcpb, toticeb, totsnwb, totgrpb, rain_cpl, rainc_cpl, snow_cpl,    &
-        pwat, frzr, frzrb, frozr, frozrb, tsnowp, tsnowpb, rhonewsn1, vrbliceden_noah, iopt_snf,                          & 
+        pwat, frzr, frzrb, frozr, frozrb, tsnowp, tsnowpb, rhonewsn1, exticeden,                                          & 
         drain_cpl, dsnow_cpl, lsm, lsm_ruc, lsm_noahmp, raincprv, rainncprv, iceprv, snowprv,                             &
         graupelprv, draincprv, drainncprv, diceprv, dsnowprv, dgraupelprv, dtp, dfi_radar_max_intervals,                  &
         dtend, dtidx, index_of_temperature, index_of_process_mp,ldiag3d, qdiag3d,dqdt_qmicro, lssav, num_dfi_radar,       &
@@ -38,7 +38,7 @@
       integer, intent(in) :: im, levs, kdt, nrcm, nncl, ntcw, ntrac, num_dfi_radar, index_of_process_dfi_radar
       integer, intent(in) :: imp_physics, imp_physics_gfdl, imp_physics_thompson, imp_physics_mg, imp_physics_fer_hires
       integer, intent(in) :: imp_physics_nssl
-      logical, intent(in) :: cal_pre, lssav, ldiag3d, qdiag3d, cplflx, cplchm, cpllnd, progsigma, vrbliceden_noah
+      logical, intent(in) :: cal_pre, lssav, ldiag3d, qdiag3d, cplflx, cplchm, cpllnd, progsigma, exticeden
       integer, intent(in) :: index_of_temperature,index_of_process_mp
 
       integer                                                :: dfi_radar_max_intervals
@@ -71,7 +71,7 @@
       real(kind=kind_phys), dimension(:),      intent(inout) :: drain_cpl, dsnow_cpl
 
       ! Rainfall variables previous time step
-      integer, intent(in) :: lsm, lsm_ruc, lsm_noahmp, iopt_snf
+      integer, intent(in) :: lsm, lsm_ruc, lsm_noahmp
       real(kind=kind_phys), dimension(:),      intent(inout) :: raincprv
       real(kind=kind_phys), dimension(:),      intent(inout) :: rainncprv
       real(kind=kind_phys), dimension(:),      intent(inout) :: iceprv
@@ -135,7 +135,7 @@
             frozrb(i) = frozrb(i) + graupel0(i)
          enddo
 !Compute the variable precip ice density for specific LSM schemes and options
-         if ( lsm == lsm_ruc .or. (lsm == lsm_noahmp .and. iopt_snf == 5) .or. vrbliceden_noah == .true.) then
+         if (exticeden) then
             snowrat = 0.
             grauprat = 0.
             icerat = 0.

--- a/physics/GFS_MP_generic_post.meta
+++ b/physics/GFS_MP_generic_post.meta
@@ -342,19 +342,12 @@
   type = real
   kind = kind_phys
   intent = inout
-[vrbliceden_noah]
-  standard_name = do_variable_surface_frozen_precipitation_density
-  long_name = flag for variable precip ice density
+[exticeden]
+  standard_name = do_external_surface_frozen_precipitation_density
+  long_name = flag for calculating frozen precip ice density outside of the LSM
   units = flag
   dimensions = ()
   type = logical
-  intent = in
-[iopt_snf]
-  standard_name = control_for_land_surface_scheme_precipitation_type_partition
-  long_name = choice for precipitation partition option (see noahmp module for definition)
-  units = index
-  dimensions = ()
-  type = integer
   intent = in
 [save_t]
   standard_name = air_temperature_save

--- a/physics/GFS_MP_generic_post.meta
+++ b/physics/GFS_MP_generic_post.meta
@@ -287,7 +287,7 @@
   kind = kind_phys
   intent = inout
 [frzr]
-  standard_name = lwe_thickness_of_surface_freezing_rain_amount
+  standard_name = cumulative_lwe_thickness_of_surface_freezing_rain_amount
   long_name = accumulated surface freezing rain
   units = m
   dimensions = (horizontal_loop_extent)
@@ -295,7 +295,7 @@
   kind = kind_phys
   intent = inout
 [frzrb]
-  standard_name = lwe_thickness_of_surface_freezing_rain_amount_in_bucket
+  standard_name = cumulative_lwe_thickness_of_surface_freezing_rain_amount_in_bucket
   long_name = accumulated surface freezing rain in bucket
   units = m
   dimensions = (horizontal_loop_extent)
@@ -303,7 +303,7 @@
   kind = kind_phys
   intent = inout
 [frozr]
-  standard_name = lwe_thickness_of_surface_graupel_amount
+  standard_name = cumulative_lwe_thickness_of_surface_graupel_amount
   long_name = accumulated surface graupel
   units = m
   dimensions = (horizontal_loop_extent)
@@ -311,7 +311,7 @@
   kind = kind_phys
   intent = inout
 [frozrb]
-  standard_name = lwe_thickness_of_surface_graupel_amount_in_bucket
+  standard_name = cumulative_lwe_thickness_of_surface_graupel_amount_in_bucket
   long_name = accumulated surface graupel in bucket
   units = m
   dimensions = (horizontal_loop_extent)
@@ -319,7 +319,7 @@
   kind = kind_phys
   intent = inout
 [tsnowp]
-  standard_name = lwe_thickness_of_surface_snow_amount
+  standard_name = cumulative_lwe_thickness_of_surface_snow_amount
   long_name = accumulated surface snow
   units = m
   dimensions = (horizontal_loop_extent)
@@ -327,7 +327,7 @@
   kind = kind_phys
   intent = inout
 [tsnowpb]
-  standard_name = lwe_thickness_of_surface_snow_amount_in_bucket
+  standard_name = cumulative_lwe_thickness_of_surface_snow_amount_in_bucket
   long_name = accumulated surface snow in bucket
   units = m
   dimensions = (horizontal_loop_extent)

--- a/physics/GFS_MP_generic_post.meta
+++ b/physics/GFS_MP_generic_post.meta
@@ -150,6 +150,14 @@
   type = real
   kind = kind_phys
   intent = in
+[rhowater]
+  standard_name = fresh_liquid_water_density_at_0c
+  long_name = density of liquid water
+  units = kg m-3
+  dimensions = ()
+  type = real
+  kind = kind_phys
+  intent = in
 [dtf]
   standard_name = timestep_for_dynamics
   long_name = dynamics timestep
@@ -279,7 +287,7 @@
   kind = kind_phys
   intent = inout
 [frzr]
-  standard_name = lwe_thickness_of_sfc_freezing_rain_amount
+  standard_name = lwe_thickness_of_surface_freezing_rain_amount
   long_name = accumulated surface freezing rain
   units = m
   dimensions = (horizontal_loop_extent)
@@ -287,7 +295,7 @@
   kind = kind_phys
   intent = inout
 [frzrb]
-  standard_name = lwe_thickness_of_sfc_freezing_rain_amount_in_bucket
+  standard_name = lwe_thickness_of_surface_freezing_rain_amount_in_bucket
   long_name = accumulated surface freezing rain in bucket
   units = m
   dimensions = (horizontal_loop_extent)
@@ -295,7 +303,7 @@
   kind = kind_phys
   intent = inout
 [frozr]
-  standard_name = lwe_thickness_of_sfc_graupel_amount
+  standard_name = lwe_thickness_of_surface_graupel_amount
   long_name = accumulated surface graupel
   units = m
   dimensions = (horizontal_loop_extent)
@@ -303,7 +311,7 @@
   kind = kind_phys
   intent = inout
 [frozrb]
-  standard_name = lwe_thickness_of_sfc_graupel_amount_in_bucket
+  standard_name = lwe_thickness_of_surface_graupel_amount_in_bucket
   long_name = accumulated surface graupel in bucket
   units = m
   dimensions = (horizontal_loop_extent)
@@ -311,7 +319,7 @@
   kind = kind_phys
   intent = inout
 [tsnowp]
-  standard_name = lwe_thickness_of_sfc_snow_amount
+  standard_name = lwe_thickness_of_surface_snow_amount
   long_name = accumulated surface snow
   units = m
   dimensions = (horizontal_loop_extent)
@@ -319,7 +327,7 @@
   kind = kind_phys
   intent = inout
 [tsnowpb]
-  standard_name = lwe_thickness_of_sfc_snow_amount_in_bucket
+  standard_name = lwe_thickness_of_surface_snow_amount_in_bucket
   long_name = accumulated surface snow in bucket
   units = m
   dimensions = (horizontal_loop_extent)
@@ -327,7 +335,7 @@
   kind = kind_phys
   intent = inout
 [rhonewsn1]
-  standard_name = lwe_density_of_precip_ice
+  standard_name = surface_frozen_precipitation_density
   long_name = density of precipitation ice
   units = kg m-3
   dimensions = (horizontal_loop_extent)
@@ -335,7 +343,7 @@
   kind = kind_phys
   intent = inout
 [vrbliceden_noah]
-  standard_name = flag_for_vrbl_prcp_ice_den
+  standard_name = do_variable_surface_frozen_precipitation_density
   long_name = flag for variable precip ice density
   units = flag
   dimensions = ()

--- a/physics/lsm_noah.f
+++ b/physics/lsm_noah.f
@@ -221,7 +221,7 @@
      &       bexppert, xlaipert, vegfpert,pertvegf,                     &  ! sfc perts, mgehne
      &       albdvis_lnd, albdnir_lnd, albivis_lnd, albinir_lnd,        &  
      &       adjvisbmd, adjnirbmd, adjvisdfd, adjnirdfd, rhonewsn1,     &  
-     &       vrbliceden_noah,                                           &
+     &       exticeden,                                                 &
 !  ---  in/outs:
      &       weasd, snwdph, tskin, tprcp, srflag, smc, stc, slc,        &
      &       canopy, trans, tsurf, zorl,                                &
@@ -272,7 +272,7 @@
 
       logical, dimension(:), intent(in) :: flag_iter, flag_guess, land
 
-      logical, intent(in) :: lheatstrg, vrbliceden_noah
+      logical, intent(in) :: lheatstrg, exticeden
 
 !  ---  in/out:
       real (kind=kind_phys), dimension(:), intent(inout) :: weasd,      &
@@ -531,7 +531,7 @@
      &       swdn, solnet, lwdn, sfcems, sfcprs, sfctmp,                &
      &       sfcspd, prcp, q2, q2sat, dqsdt2, th2, ivegsrc,             &
      &       vtype, stype, slope, shdmin1d, alb, snoalb1d,              &
-     &       rhonewsn, vrbliceden_noah,                                 &
+     &       rhonewsn, exticeden,                                       &
      &       bexpp, xlaip,                                              & ! sfc-perts, mgehne
      &       lheatstrg,                                                 &
 !  ---  input/outputs:

--- a/physics/lsm_noah.meta
+++ b/physics/lsm_noah.meta
@@ -494,9 +494,9 @@
   type = real
   kind = kind_phys
   intent = in
-[vrbliceden_noah]
-  standard_name = do_variable_surface_frozen_precipitation_density
-  long_name = flag for variable precip ice density
+[exticeden]
+  standard_name = do_external_surface_frozen_precipitation_density
+  long_name = flag for calculating frozen precip ice density outside of the LSM
   units = flag
   dimensions = ()
   type = logical

--- a/physics/lsm_noah.meta
+++ b/physics/lsm_noah.meta
@@ -487,7 +487,7 @@
   kind = kind_phys
   intent = in
 [rhonewsn1]
-  standard_name = lwe_density_of_precip_ice
+  standard_name = surface_frozen_precipitation_density
   long_name = density of precipitation ice
   units = kg m-3
   dimensions = (horizontal_loop_extent)
@@ -495,7 +495,7 @@
   kind = kind_phys
   intent = in
 [vrbliceden_noah]
-  standard_name = flag_for_vrbl_prcp_ice_den
+  standard_name = do_variable_surface_frozen_precipitation_density
   long_name = flag for variable precip ice density
   units = flag
   dimensions = ()

--- a/physics/lsm_ruc.F90
+++ b/physics/lsm_ruc.F90
@@ -355,7 +355,7 @@ module lsm_ruc
      &       cm_ice, ch_ice, snowfallac_ice,                            &
      &       albdvis_ice, albdnir_ice,  albivis_ice,  albinir_ice,      &
      ! --- out
-     &       rhosnf, sbsno,                                             &
+     &       sbsno,                                                     &
      &       cmm_lnd, chh_lnd, cmm_ice, chh_ice,                        &
      !
      &       flag_iter, flag_guess, flag_init, lsm_cold_start,          &
@@ -426,7 +426,7 @@ module lsm_ruc
 
 !  ---  output:
       real (kind=kind_phys), dimension(:), intent(inout) ::              &
-     &       rhosnf, runof, drain, runoff, srunoff, evbs, evcw,          &
+     &       runof, drain, runoff, srunoff, evbs, evcw,                  &
      &       stm, wetness, semisbase, semis_lnd, semis_ice,              &
      &       sfalb_lnd, sfalb_ice,                                       &
      ! for land
@@ -492,7 +492,7 @@ module lsm_ruc
      &     sneqv_lnd, snoalb1d_lnd, snowh_lnd, snoh_lnd, tsnav_lnd,     &
      &     snomlt_lnd, sncovr_lnd, soilw, soilm, ssoil_lnd,             &
      &     soilt_lnd, tbot,                                             &
-     &     xlai, swdn, z0_lnd, znt_lnd, rhosnfr, infiltr,               &
+     &     xlai, swdn, z0_lnd, znt_lnd, infiltr,                        &
      &     precipfr, snfallac_lnd, acsn,                                &
      &     qsfc_lnd, qsg_lnd, qvg_lnd, qcg_lnd, soilt1_lnd, chklowq,    &
      &     rhonewsn
@@ -747,7 +747,6 @@ module lsm_ruc
           acrunoff(i,j)     = 0.0
           snfallac_lnd(i,j) = 0.0
           snfallac_ice(i,j) = 0.0
-          rhosnfr(i,j)      = 0.0
           precipfr(i,j)     = 0.0
 
         endif
@@ -1122,7 +1121,7 @@ module lsm_ruc
      &          zs, prcp(i,j), sneqv_lnd(i,j), snowh_lnd(i,j),               &
      &          sncovr_lnd(i,j),                                             &
      &          ffrozp(i,j), frpcpn,                                         &
-     &          rhosnfr(i,j), precipfr(i,j),                                 &
+     &          precipfr(i,j),                                               &
 !  ---  inputs:
      &          conflx2(i,1,j), sfcprs(i,1,j), sfctmp(i,1,j), q2(i,1,j),     &
      &          qcatm(i,1,j), rho2(i,1,j), semis_bck(i,j), lwdn(i,j),        &
@@ -1246,7 +1245,6 @@ module lsm_ruc
         sfcqv_lnd(i)  = qvg_lnd(i,j)
         sfcqc_lnd(i)  = qcg_lnd(i,j)
         !  --- ...  units [m/s] = [g m-2 s-1]
-        rhosnf(i) = rhosnfr(i,j)
         !acsnow(i) = acsn(i,j)     ! kg m-2
 
         ! --- ... accumulated total runoff and surface runoff
@@ -1396,7 +1394,7 @@ module lsm_ruc
      &          zs, prcp(i,j), sneqv_ice(i,j), snowh_ice(i,j),               &
      &          sncovr_ice(i,j),                                             &
      &          ffrozp(i,j), frpcpn,                                         &
-     &          rhosnfr(i,j), precipfr(i,j),                                 &
+     &          precipfr(i,j),                                               &
 !  ---  inputs:
      &          conflx2(i,1,j), sfcprs(i,1,j), sfctmp(i,1,j), q2(i,1,j),     &
      &          qcatm(i,1,j), rho2(i,1,j), semis_bck(i,j), lwdn(i,j),        &

--- a/physics/lsm_ruc.F90
+++ b/physics/lsm_ruc.F90
@@ -323,8 +323,8 @@ module lsm_ruc
       subroutine lsm_ruc_run                                            & ! inputs
      &     ( iter, me, master, delt, kdt, im, nlev, lsm_ruc, lsm,       &
      &       imp_physics, imp_physics_gfdl, imp_physics_thompson,       &
-     &       imp_physics_nssl,                                          &
-     &       do_mynnsfclay, lsoil_ruc, lsoil, rdlai, xlat_d, xlon_d, zs,&
+     &       imp_physics_nssl, do_mynnsfclay, vrbliceden,               &
+     &       lsoil_ruc, lsoil, rdlai, xlat_d, xlon_d, zs,               &
      &       t1, q1, qc, stype, vtype, sigmaf, laixy,                   &
      &       dlwflx, dswsfc, tg3, coszen, land, icy, use_lake,          &
      &       rainnc, rainc, ice, snow, graupel,                         &
@@ -355,7 +355,7 @@ module lsm_ruc
      &       cm_ice, ch_ice, snowfallac_ice,                            &
      &       albdvis_ice, albdnir_ice,  albivis_ice,  albinir_ice,      &
      ! --- out
-     &       sbsno,                                                     &
+     &       rhosnf, sbsno,                                             &
      &       cmm_lnd, chh_lnd, cmm_ice, chh_ice,                        &
      !
      &       flag_iter, flag_guess, flag_init, lsm_cold_start,          &
@@ -397,6 +397,7 @@ module lsm_ruc
       logical, dimension(:),  intent(in) :: flag_cice
       logical,                intent(in) :: frac_grid
       logical,                intent(in) :: do_mynnsfclay
+      logical,                intent(in) :: vrbliceden
 
       logical,                intent(in) :: rdlai
 
@@ -426,7 +427,7 @@ module lsm_ruc
 
 !  ---  output:
       real (kind=kind_phys), dimension(:), intent(inout) ::              &
-     &       runof, drain, runoff, srunoff, evbs, evcw,                  &
+     &       rhosnf, runof, drain, runoff, srunoff, evbs, evcw,          &
      &       stm, wetness, semisbase, semis_lnd, semis_ice,              &
      &       sfalb_lnd, sfalb_ice,                                       &
      ! for land
@@ -492,7 +493,7 @@ module lsm_ruc
      &     sneqv_lnd, snoalb1d_lnd, snowh_lnd, snoh_lnd, tsnav_lnd,     &
      &     snomlt_lnd, sncovr_lnd, soilw, soilm, ssoil_lnd,             &
      &     soilt_lnd, tbot,                                             &
-     &     xlai, swdn, z0_lnd, znt_lnd, infiltr,                        &
+     &     xlai, swdn, z0_lnd, znt_lnd, rhosnfr, infiltr,               &
      &     precipfr, snfallac_lnd, acsn,                                &
      &     qsfc_lnd, qsg_lnd, qvg_lnd, qcg_lnd, soilt1_lnd, chklowq,    &
      &     rhonewsn
@@ -747,6 +748,7 @@ module lsm_ruc
           acrunoff(i,j)     = 0.0
           snfallac_lnd(i,j) = 0.0
           snfallac_ice(i,j) = 0.0
+          rhosnfr(i,j)      = 0.0
           precipfr(i,j)     = 0.0
 
         endif
@@ -1121,7 +1123,7 @@ module lsm_ruc
      &          zs, prcp(i,j), sneqv_lnd(i,j), snowh_lnd(i,j),               &
      &          sncovr_lnd(i,j),                                             &
      &          ffrozp(i,j), frpcpn,                                         &
-     &          precipfr(i,j),                                               &
+     &          rhosnfr(i,j), precipfr(i,j), vrbliceden,                     &
 !  ---  inputs:
      &          conflx2(i,1,j), sfcprs(i,1,j), sfctmp(i,1,j), q2(i,1,j),     &
      &          qcatm(i,1,j), rho2(i,1,j), semis_bck(i,j), lwdn(i,j),        &
@@ -1245,6 +1247,7 @@ module lsm_ruc
         sfcqv_lnd(i)  = qvg_lnd(i,j)
         sfcqc_lnd(i)  = qcg_lnd(i,j)
         !  --- ...  units [m/s] = [g m-2 s-1]
+        rhosnf(i) = rhosnfr(i,j)
         !acsnow(i) = acsn(i,j)     ! kg m-2
 
         ! --- ... accumulated total runoff and surface runoff
@@ -1394,7 +1397,7 @@ module lsm_ruc
      &          zs, prcp(i,j), sneqv_ice(i,j), snowh_ice(i,j),               &
      &          sncovr_ice(i,j),                                             &
      &          ffrozp(i,j), frpcpn,                                         &
-     &          precipfr(i,j),                                               &
+     &          rhosnfr(i,j), precipfr(i,j), vrbliceden,                     &
 !  ---  inputs:
      &          conflx2(i,1,j), sfcprs(i,1,j), sfctmp(i,1,j), q2(i,1,j),     &
      &          qcatm(i,1,j), rho2(i,1,j), semis_bck(i,j), lwdn(i,j),        &

--- a/physics/lsm_ruc.F90
+++ b/physics/lsm_ruc.F90
@@ -323,7 +323,7 @@ module lsm_ruc
       subroutine lsm_ruc_run                                            & ! inputs
      &     ( iter, me, master, delt, kdt, im, nlev, lsm_ruc, lsm,       &
      &       imp_physics, imp_physics_gfdl, imp_physics_thompson,       &
-     &       imp_physics_nssl, do_mynnsfclay, vrbliceden,               &
+     &       imp_physics_nssl, do_mynnsfclay, exticeden,                &
      &       lsoil_ruc, lsoil, rdlai, xlat_d, xlon_d, zs,               &
      &       t1, q1, qc, stype, vtype, sigmaf, laixy,                   &
      &       dlwflx, dswsfc, tg3, coszen, land, icy, use_lake,          &
@@ -397,7 +397,7 @@ module lsm_ruc
       logical, dimension(:),  intent(in) :: flag_cice
       logical,                intent(in) :: frac_grid
       logical,                intent(in) :: do_mynnsfclay
-      logical,                intent(in) :: vrbliceden
+      logical,                intent(in) :: exticeden
 
       logical,                intent(in) :: rdlai
 
@@ -1123,7 +1123,7 @@ module lsm_ruc
      &          zs, prcp(i,j), sneqv_lnd(i,j), snowh_lnd(i,j),               &
      &          sncovr_lnd(i,j),                                             &
      &          ffrozp(i,j), frpcpn,                                         &
-     &          rhosnfr(i,j), precipfr(i,j), vrbliceden,                     &
+     &          rhosnfr(i,j), precipfr(i,j), exticeden,                      &
 !  ---  inputs:
      &          conflx2(i,1,j), sfcprs(i,1,j), sfctmp(i,1,j), q2(i,1,j),     &
      &          qcatm(i,1,j), rho2(i,1,j), semis_bck(i,j), lwdn(i,j),        &
@@ -1397,7 +1397,7 @@ module lsm_ruc
      &          zs, prcp(i,j), sneqv_ice(i,j), snowh_ice(i,j),               &
      &          sncovr_ice(i,j),                                             &
      &          ffrozp(i,j), frpcpn,                                         &
-     &          rhosnfr(i,j), precipfr(i,j), vrbliceden,                     &
+     &          rhosnfr(i,j), precipfr(i,j), exticeden,                      &
 !  ---  inputs:
      &          conflx2(i,1,j), sfcprs(i,1,j), sfctmp(i,1,j), q2(i,1,j),     &
      &          qcatm(i,1,j), rho2(i,1,j), semis_bck(i,j), lwdn(i,j),        &

--- a/physics/lsm_ruc.F90
+++ b/physics/lsm_ruc.F90
@@ -748,7 +748,7 @@ module lsm_ruc
           acrunoff(i,j)     = 0.0
           snfallac_lnd(i,j) = 0.0
           snfallac_ice(i,j) = 0.0
-          rhosnfr(i,j)      = 0.0
+          rhosnfr(i,j)      = -1.e3
           precipfr(i,j)     = 0.0
 
         endif

--- a/physics/lsm_ruc.meta
+++ b/physics/lsm_ruc.meta
@@ -634,6 +634,13 @@
   dimensions = ()
   type = logical
   intent = in
+[vrbliceden]
+  standard_name = do_variable_surface_frozen_precipitation_density
+  long_name = flag for variable precip ice density
+  units = flag
+  dimensions = ()
+  type = logical
+  intent = in
 [lsoil_ruc]
   standard_name = vertical_dimension_of_soil_internal_to_land_surface_scheme
   long_name = number of soil layers internal to land surface model
@@ -1512,6 +1519,14 @@
   type = real
   kind = kind_phys
   intent = out
+[rhosnf]
+  standard_name = lsm_internal_surface_frozen_precipitation_density
+  long_name = density of frozen precipitation
+  units = kg m-3
+  dimensions = (horizontal_loop_extent)
+  type = real
+  kind = kind_phys
+  intent = inout
 [sbsno]
   standard_name = snow_deposition_sublimation_upward_latent_heat_flux
   long_name = latent heat flux from snow depo/subl

--- a/physics/lsm_ruc.meta
+++ b/physics/lsm_ruc.meta
@@ -953,7 +953,7 @@
   kind = kind_phys
   intent = in
 [rhonewsn1]
-  standard_name = lwe_density_of_precip_ice
+  standard_name = surface_frozen_precipitation_density
   long_name = density of precipitation ice
   units = kg m-3
   dimensions = (horizontal_loop_extent)
@@ -1512,14 +1512,6 @@
   type = real
   kind = kind_phys
   intent = out
-[rhosnf]
-  standard_name = frozen_precipitation_density
-  long_name = density of frozen precipitation
-  units = kg m-3
-  dimensions = (horizontal_loop_extent)
-  type = real
-  kind = kind_phys
-  intent = inout
 [sbsno]
   standard_name = snow_deposition_sublimation_upward_latent_heat_flux
   long_name = latent heat flux from snow depo/subl

--- a/physics/lsm_ruc.meta
+++ b/physics/lsm_ruc.meta
@@ -634,9 +634,9 @@
   dimensions = ()
   type = logical
   intent = in
-[vrbliceden]
-  standard_name = do_variable_surface_frozen_precipitation_density
-  long_name = flag for variable precip ice density
+[exticeden]
+  standard_name = do_external_surface_frozen_precipitation_density
+  long_name = flag for calculating frozen precip ice density outside of the LSM
   units = flag
   dimensions = ()
   type = logical

--- a/physics/module_sf_ruclsm.F90
+++ b/physics/module_sf_ruclsm.F90
@@ -54,7 +54,7 @@ CONTAINS
                    DT,init,lsm_cold_start,KTAU,iter,NSL,         &
                    graupelncv,snowncv,rainncv,raincv,            &
                    ZS,RAINBL,SNOW,SNOWH,SNOWC,FRZFRAC,frpcpn,    &
-                   rhosnf,precipfr,                              &
+                   precipfr,                                     &
                    Z3D,P8W,T3D,QV3D,QC3D,RHO3D,EMISBCK,          &
                    GLW,GSWdn,GSW,EMISS,CHKLOWQ, CHS,             &
                    FLQC,FLHC,rhonewsn,MAVAIL,CANWAT,VEGFRA,ALB,  &
@@ -296,14 +296,12 @@ CONTAINS
                                                          SMFR3D
 
    REAL,       DIMENSION( ims:ime, jms:jme ), INTENT(OUT)     :: &
-                                                         RHOSNF, & !RHO of snowfall
                                                        PRECIPFR, & ! time-step frozen precip
                                                      SNOWFALLAC
 !--- soil/snow properties
    REAL                                                          &
                              ::                           RHOCS, &
                                                           RHOSN, &
-                                                      RHOSNFALL, &
                                                            BCLH, &
                                                             DQM, &
                                                            KSAT, &
@@ -457,7 +455,6 @@ CONTAINS
            ACSNOW(i,j) = 0.
            SNOWFALLAC(i,j) = 0.
            PRECIPFR(i,j) = 0.
-           RHOSNF(i,j) = -1.e3 ! non-zero flag
            SNFLX(i,j) = 0.
            DEW  (i,j) = 0.
            PC   (i,j) = 0.
@@ -622,7 +619,6 @@ CONTAINS
          CANWATR=CANWAT(I,J)*1.E-3
 
          SNOWFRAC=SNOWC(I,J)
-         RHOSNFALL=RHOSNF(I,J)
 
          snowold(i,j)=snwe
 !-----
@@ -894,7 +890,7 @@ CONTAINS
                 nzs,nddzs,nroot,meltfactor,                      &   !added meltfactor
                 iland,isoil,ivgtyp(i,j),isltyp(i,j),             &
                 PRCPMS, NEWSNMS,SNWE,SNHEI,SNOWFRAC,             &
-                RHOSN,RHONEWSN(I,J),RHOSNFALL,                   &
+                RHOSN,RHONEWSN(I,J),                             &
                 snowrat,grauprat,icerat,curat,                   &
                 PATM,TABS,QVATM,QCATM,RHO,                       &
                 GLW(I,J),GSWdn(i,j),GSW(I,J),                    &
@@ -1073,9 +1069,6 @@ endif
 
        SNOWC(I,J)=SNOWFRAC
 
-!--- RHOSNF - density of snowfall
-       RHOSNF(I,J)=RHOSNFALL
-
 ! Accumulated moisture flux [kg/m^2]
        SFCEVP (I,J) = SFCEVP (I,J) + QFX (I,J) * DT
 
@@ -1161,7 +1154,7 @@ endif
                 nzs,nddzs,nroot,meltfactor,                      &
                 ILAND,ISOIL,IVGTYP,ISLTYP,PRCPMS,                &
                 NEWSNMS,SNWE,SNHEI,SNOWFRAC,                     &
-                RHOSN,RHONEWSN,RHOSNFALL,                        &
+                RHOSN,RHONEWSN,                                  &
                 snowrat,grauprat,icerat,curat,                   &
                 PATM,TABS,QVATM,QCATM,rho,                       &
                 GLW,GSWdn,GSW,EMISS,EMISBCK,QKMS,TKMS,PC,        &
@@ -1281,7 +1274,6 @@ endif
                                                           EVAPL, &
                                                         INFILTR, &
                                                           RHOSN, & 
-                                                      rhosnfall, &
                                                         snowrat, &
                                                        grauprat, &
                                                          icerat, &

--- a/physics/module_sf_ruclsm.F90
+++ b/physics/module_sf_ruclsm.F90
@@ -54,11 +54,11 @@ CONTAINS
                    DT,init,lsm_cold_start,KTAU,iter,NSL,         &
                    graupelncv,snowncv,rainncv,raincv,            &
                    ZS,RAINBL,SNOW,SNOWH,SNOWC,FRZFRAC,frpcpn,    &
-                   precipfr,                                     &
+                   rhosnf,precipfr,vrbliceden,                   &
                    Z3D,P8W,T3D,QV3D,QC3D,RHO3D,EMISBCK,          &
                    GLW,GSWdn,GSW,EMISS,CHKLOWQ, CHS,             &
-                   FLQC,FLHC,rhonewsn,MAVAIL,CANWAT,VEGFRA,ALB,  &
-                   ZNT,Z0,SNOALB,ALBBCK,LAI,                     & 
+                   FLQC,FLHC,rhonewsn_ex,MAVAIL,CANWAT,VEGFRA,   &
+                   ALB, ZNT,Z0,SNOALB,ALBBCK,LAI,                & 
                    landusef, nlcat,                              & ! mosaic_lu, mosaic_soil, &
                    soilctop, nscat,                              &
                    QSFC,QSG,QVG,QCG,DEW,SOILT1,TSNAV,            &
@@ -157,7 +157,7 @@ CONTAINS
 !   INTEGER,     PARAMETER            ::     nddzs=2*(nzss-2)
 
    REAL,       INTENT(IN   )    ::     DT
-   LOGICAL,    INTENT(IN   )    ::     myj,frpcpn,init,lsm_cold_start
+   LOGICAL,    INTENT(IN   )    ::     myj,frpcpn,init,lsm_cold_start,vrbliceden
    INTEGER,    INTENT(IN   )    ::     NLCAT, NSCAT ! , mosaic_lu, mosaic_soil
    INTEGER,    INTENT(IN   )    ::     ktau, iter, nsl, isice, iswater, &
                                        ims,ime, jms,jme, kms,kme, &
@@ -192,7 +192,7 @@ CONTAINS
                                                         SNOWNCV, &
                                                          RAINCV, &
                                                         RAINNCV, &
-                                                        RHONEWSN
+                                                    RHONEWSN_ex     !externally-calculated srf frz precip density
 !   REAL,       DIMENSION( ims:ime , jms:jme ),                   &
 !               INTENT(IN   )    ::                     lakemask
 !   INTEGER,    INTENT(IN   )    ::                    LakeModel
@@ -296,12 +296,15 @@ CONTAINS
                                                          SMFR3D
 
    REAL,       DIMENSION( ims:ime, jms:jme ), INTENT(OUT)     :: &
+                                                         RHOSNF, & !RHO of snowfall
                                                        PRECIPFR, & ! time-step frozen precip
                                                      SNOWFALLAC
 !--- soil/snow properties
    REAL                                                          &
                              ::                           RHOCS, &
+                                                       RHONEWSN, &
                                                           RHOSN, &
+                                                      RHOSNFALL, &
                                                            BCLH, &
                                                             DQM, &
                                                            KSAT, &
@@ -455,6 +458,7 @@ CONTAINS
            ACSNOW(i,j) = 0.
            SNOWFALLAC(i,j) = 0.
            PRECIPFR(i,j) = 0.
+           RHOSNF(i,j) = -1.e3 ! non-zero flag
            SNFLX(i,j) = 0.
            DEW  (i,j) = 0.
            PC   (i,j) = 0.
@@ -619,6 +623,7 @@ CONTAINS
          CANWATR=CANWAT(I,J)*1.E-3
 
          SNOWFRAC=SNOWC(I,J)
+         RHOSNFALL=RHOSNF(I,J)
 
          snowold(i,j)=snwe
 !-----
@@ -680,6 +685,7 @@ CONTAINS
         NROOT= 4
 !           ! rooting depth
 
+        RHONEWSN = 200.
        if(SNOW(i,j).gt.0. .and. SNOWH(i,j).gt.0.) then
         RHOSN = SNOW(i,j)/SNOWH(i,j)
        else
@@ -890,8 +896,8 @@ CONTAINS
                 nzs,nddzs,nroot,meltfactor,                      &   !added meltfactor
                 iland,isoil,ivgtyp(i,j),isltyp(i,j),             &
                 PRCPMS, NEWSNMS,SNWE,SNHEI,SNOWFRAC,             &
-                RHOSN,RHONEWSN(I,J),                             &
-                snowrat,grauprat,icerat,curat,                   &
+                vrbliceden,RHOSN,RHONEWSN_ex(I,J),RHONEWSN,      &
+                RHOSNFALL,snowrat,grauprat,icerat,curat,         &
                 PATM,TABS,QVATM,QCATM,RHO,                       &
                 GLW(I,J),GSWdn(i,j),GSW(I,J),                    &
                 EMISSL(I,J),EMISBCK(I,J),                        &
@@ -1069,6 +1075,9 @@ endif
 
        SNOWC(I,J)=SNOWFRAC
 
+!--- RHOSNF - density of snowfall
+       RHOSNF(I,J)=RHOSNFALL
+
 ! Accumulated moisture flux [kg/m^2]
        SFCEVP (I,J) = SFCEVP (I,J) + QFX (I,J) * DT
 
@@ -1154,7 +1163,7 @@ endif
                 nzs,nddzs,nroot,meltfactor,                      &
                 ILAND,ISOIL,IVGTYP,ISLTYP,PRCPMS,                &
                 NEWSNMS,SNWE,SNHEI,SNOWFRAC,                     &
-                RHOSN,RHONEWSN,                                  &
+                vrbliceden,RHOSN,RHONEWSN_ex,RHONEWSN,RHOSNFALL, &
                 snowrat,grauprat,icerat,curat,                   &
                 PATM,TABS,QVATM,QCATM,rho,                       &
                 GLW,GSWdn,GSW,EMISS,EMISBCK,QKMS,TKMS,PC,        &
@@ -1182,8 +1191,8 @@ endif
                                  nddzs                             !nddzs=2*(nzs-2)
 
    REAL,     INTENT(IN   )   ::  DELT,CONFLX,meltfactor
-   REAL,     INTENT(IN   )   ::  C1SN,C2SN,RHONEWSN
-   LOGICAL,    INTENT(IN   )    ::     myj, debug_print
+   REAL,     INTENT(IN   )   ::  C1SN,C2SN,RHONEWSN_ex
+   LOGICAL,    INTENT(IN   )    ::     myj, debug_print, vrbliceden
 !--- 3-D Atmospheric variables
    REAL                                                        , &
             INTENT(IN   )    ::                            PATM, &
@@ -1273,7 +1282,9 @@ endif
                                                            EETA, &
                                                           EVAPL, &
                                                         INFILTR, &
-                                                          RHOSN, & 
+                                                          RHOSN, &
+                                                       RHONEWSN, &
+                                                      rhosnfall, & 
                                                         snowrat, &
                                                        grauprat, &
                                                          icerat, &
@@ -1484,13 +1495,22 @@ endif
 !--- 27 Feb 2014 - empirical formulations from John M. Brown
 !        rhonewsn=min(250.,rhowater/max(4.179,(13.*tanh((274.15-Tabs)*0.3333))))
 !--- 13 Mar 2018 - formulation from Trevor Elcott
-
+      if (vrbliceden) then
+        rhonewsn = rhonewsn_ex
+      else
+        rhonewsn=min(125.,1000.0/max(8.,(17.*tanh((276.65-Tabs)*0.15))))
+        rhonewgr=min(500.,rhowater/max(2.,(3.5*tanh((274.15-Tabs)*0.3333))))
+        rhonewice=rhonewsn
 !--- compute density of "snowfall" from weighted contribution
 !                 of snow, graupel and ice fractions
 
+        rhosnfall = min(500.,max(58.8,(rhonewsn*snowrat +  &
 !13mar18         rhosnfall = min(500.,max(76.9,(rhonewsn*snowrat +  &
+                     rhonewgr*grauprat + rhonewice*icerat + rhonewgr*curat)))
 
 ! from now on rhonewsn is the density of falling frozen precipitation
+        rhonewsn=rhosnfall
+      end if
 
 !*** Define average snow density of the snow pack considering
 !*** the amount of fresh snow (eq. 9 in Koren et al.(1999) 

--- a/physics/module_sf_ruclsm.F90
+++ b/physics/module_sf_ruclsm.F90
@@ -54,7 +54,7 @@ CONTAINS
                    DT,init,lsm_cold_start,KTAU,iter,NSL,         &
                    graupelncv,snowncv,rainncv,raincv,            &
                    ZS,RAINBL,SNOW,SNOWH,SNOWC,FRZFRAC,frpcpn,    &
-                   rhosnf,precipfr,vrbliceden,                   &
+                   rhosnf,precipfr,exticeden,                    &
                    Z3D,P8W,T3D,QV3D,QC3D,RHO3D,EMISBCK,          &
                    GLW,GSWdn,GSW,EMISS,CHKLOWQ, CHS,             &
                    FLQC,FLHC,rhonewsn_ex,MAVAIL,CANWAT,VEGFRA,   &
@@ -157,7 +157,7 @@ CONTAINS
 !   INTEGER,     PARAMETER            ::     nddzs=2*(nzss-2)
 
    REAL,       INTENT(IN   )    ::     DT
-   LOGICAL,    INTENT(IN   )    ::     myj,frpcpn,init,lsm_cold_start,vrbliceden
+   LOGICAL,    INTENT(IN   )    ::     myj,frpcpn,init,lsm_cold_start,exticeden
    INTEGER,    INTENT(IN   )    ::     NLCAT, NSCAT ! , mosaic_lu, mosaic_soil
    INTEGER,    INTENT(IN   )    ::     ktau, iter, nsl, isice, iswater, &
                                        ims,ime, jms,jme, kms,kme, &
@@ -896,7 +896,7 @@ CONTAINS
                 nzs,nddzs,nroot,meltfactor,                      &   !added meltfactor
                 iland,isoil,ivgtyp(i,j),isltyp(i,j),             &
                 PRCPMS, NEWSNMS,SNWE,SNHEI,SNOWFRAC,             &
-                vrbliceden,RHOSN,RHONEWSN_ex(I,J),RHONEWSN,      &
+                exticeden,RHOSN,RHONEWSN_ex(I,J),RHONEWSN,       &
                 RHOSNFALL,snowrat,grauprat,icerat,curat,         &
                 PATM,TABS,QVATM,QCATM,RHO,                       &
                 GLW(I,J),GSWdn(i,j),GSW(I,J),                    &
@@ -1163,7 +1163,7 @@ endif
                 nzs,nddzs,nroot,meltfactor,                      &
                 ILAND,ISOIL,IVGTYP,ISLTYP,PRCPMS,                &
                 NEWSNMS,SNWE,SNHEI,SNOWFRAC,                     &
-                vrbliceden,RHOSN,RHONEWSN_ex,RHONEWSN,RHOSNFALL, &
+                exticeden,RHOSN,RHONEWSN_ex,RHONEWSN,RHOSNFALL,  &
                 snowrat,grauprat,icerat,curat,                   &
                 PATM,TABS,QVATM,QCATM,rho,                       &
                 GLW,GSWdn,GSW,EMISS,EMISBCK,QKMS,TKMS,PC,        &
@@ -1192,7 +1192,7 @@ endif
 
    REAL,     INTENT(IN   )   ::  DELT,CONFLX,meltfactor
    REAL,     INTENT(IN   )   ::  C1SN,C2SN,RHONEWSN_ex
-   LOGICAL,    INTENT(IN   )    ::     myj, debug_print, vrbliceden
+   LOGICAL,    INTENT(IN   )    ::     myj, debug_print, exticeden
 !--- 3-D Atmospheric variables
    REAL                                                        , &
             INTENT(IN   )    ::                            PATM, &
@@ -1495,7 +1495,7 @@ endif
 !--- 27 Feb 2014 - empirical formulations from John M. Brown
 !        rhonewsn=min(250.,rhowater/max(4.179,(13.*tanh((274.15-Tabs)*0.3333))))
 !--- 13 Mar 2018 - formulation from Trevor Elcott
-      if (vrbliceden) then
+      if (exticeden) then
         rhonewsn = rhonewsn_ex
       else
         rhonewsn=min(125.,1000.0/max(8.,(17.*tanh((276.65-Tabs)*0.15))))

--- a/physics/mp_thompson.meta
+++ b/physics/mp_thompson.meta
@@ -611,7 +611,7 @@
   kind = kind_phys
   intent = out
 [fullradar_diag]
-  standard_name = flag_for_computing_full_radar_reflectivity
+  standard_name = do_full_radar_reflectivity
   long_name = flag for computing full radar reflectivity
   units = flag
   dimensions = ()

--- a/physics/noahmpdrv.meta
+++ b/physics/noahmpdrv.meta
@@ -533,7 +533,7 @@
   kind = kind_phys
   intent = in
 [rhonewsn1]
-  standard_name = lwe_density_of_precip_ice
+  standard_name = surface_frozen_precipitation_density
   long_name = density of precipitation ice
   units = kg m-3
   dimensions = (horizontal_loop_extent)

--- a/physics/sflx.f
+++ b/physics/sflx.f
@@ -116,7 +116,7 @@
      &       swdn, swnet, lwdn, sfcems, sfcprs, sfctmp,                 &
      &       sfcspd, prcp, q2, q2sat, dqsdt2, th2, ivegsrc,             &
      &       vegtyp, soiltyp, slopetyp, shdmin, alb, snoalb,            &
-     &       rhonewsn, vrbliceden_noah,                                 &
+     &       rhonewsn, exticeden,                                       &
      &       bexpp, xlaip,                                              & !  sfc-perts, mgehne
      &       lheatstrg,                                                 &!  ---  input/outputs:
      &       tbot, cmc, t1, stc, smc, sh2o, sneqv, ch, cm,z0,           &!  ---  outputs:
@@ -313,7 +313,7 @@
      &       sfcspd, prcp, q2, q2sat, dqsdt2, th2, shdmin, alb, snoalb, &
      &       bexpp, xlaip, rhonewsn                                     & !sfc-perts, mgehne
 
-      logical, intent(in) :: lheatstrg, vrbliceden_noah
+      logical, intent(in) :: lheatstrg, exticeden
 
 !  ---  input/outputs:
       real (kind=kind_phys), intent(inout) :: tbot, cmc, t1, sneqv,     &
@@ -565,7 +565,7 @@
 !! using old and new snow.
         call snow_new
 !  ---  inputs:                                                         !
-!          ( sfctmp, sn_new, rhonewsn, vrbliceden_noah,                 !
+!          ( sfctmp, sn_new, rhonewsn, exticeden,                       !
 !  ---  input/outputs:                                                  !
 !            snowh, sndens )                                            !
 
@@ -2856,7 +2856,7 @@
       subroutine snow_new
 !...................................
 !  ---  inputs:
-!    &     ( sfctmp, sn_new, rhonewsn, vrbliceden_noah,                 &
+!    &     ( sfctmp, sn_new, rhonewsn, exticeden,                       &
 !  ---  input/outputs:
 !    &       snowh, sndens                                              &
 !    &     )
@@ -2905,7 +2905,7 @@
 !           snowcovered and glacierized basin', 6th nordic hydrological
 !           conference, vemadolen, sweden, 1980, 172-177pp.
 
-      if(.not. vrbliceden_noah) then
+      if(.not. exticeden) then
          if (tempc <= -15.0) then
             dsnew = 0.05
          else


### PR DESCRIPTION
Changes:

- pass in rhowater to GFS_MP_generic_post rather than redefine it
- add parenthesis in a multi-condition if statement in GFS_MP_generic_post for clarity
- change standard names of the new variables for consistency with CCPP rules
- remove redundant frozen precipitation density in RUC LSM for clarity